### PR TITLE
[Tooling] Improve CI setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jobs:
   include:
   - stage: build
     name: "Building app"
-    script: bundle exec fatlane compile_app os_version:'13.1'
+    script: bundle exec fastlane compile_app ios_version:'13.1'
 
   - stage: test
     name: "Running unit tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,27 @@ cache: bundler
 
 jobs:
   include:
+  - stage: build
+    name: "Building app"
+    script: bundle exec fatlane compile_app os_version:'13.1'
+
   - stage: test
     name: "Running unit tests"
     script: bundle exec fastlane unit_test device:'iPhone 8' ios_version:'13.1'
-    after_success: bundle exec slather
 
   - stage: test
     name: "Running UI tests"
     script: bundle exec fastlane ui_test device:'iPhone 8' ios_version:'13.1'
+
+  - stage: coverage
+    name: "Running full set of tests and gathering coverage data"
+    script: bundle exec fastlane full_test device:'iPhone 8' ios_version:'13.1'
     after_success: bundle exec slather
 
 stages:
+- name: build
+  if: (type = pull_request) AND (branch = master OR branch = develop)
 - name: test
-  if: (type = pull_request OR type = push) AND (branch = master OR branch = develop)
+  if: (type = pull_request) AND (branch = master OR branch = develop)
+- name: coverage
+  if: (type = push) AND (branch = master OR branch = develop)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # iOS Tech Challenge
 
+[![Build Status](https://travis-ci.com/peredaniel/iOS-tech-challenge.svg?branch=master)](https://travis-ci.com/peredaniel/iOS-tech-challenge)
+[![Coverage Status](https://coveralls.io/repos/github/peredaniel/iOS-tech-challenge/badge.svg)](https://coveralls.io/github/peredaniel/iOS-tech-challenge)
+
 Here at ABA English we love Music and we know our users do it also!
 
 We want to give them the opportunity to learn English while singing their favourite songs.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # iOS Tech Challenge
 
-[![Build Status](https://travis-ci.com/peredaniel/iOS-tech-challenge.svg?branch=master)](https://travis-ci.com/peredaniel/iOS-tech-challenge)
-[![Coverage Status](https://coveralls.io/repos/github/peredaniel/iOS-tech-challenge/badge.svg)](https://coveralls.io/github/peredaniel/iOS-tech-challenge)
-
 Here at ABA English we love Music and we know our users do it also!
 
 We want to give them the opportunity to learn English while singing their favourite songs.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -36,3 +36,35 @@ lane :ui_test do |options|
 	    disable_concurrent_testing: true
   	)
 end
+
+desc "Runs app's full test suite in the specified device."
+desc "Usage example: fastlane full_test device:'iPhone 8' ios_version:'12.4'"
+lane :full_test do |options| 
+	raise "Missing 'device' parameter. Usage: fastlane full_test device:DEVICE ios_version:IOS_VERSION" unless options[:device]
+	raise "Missing 'ios_version' parameter. Usage: fastlane full_test device:DEVICE ios_version:IOS_VERSION" unless options[:ios_version]
+	ios_version = options[:ios_version]
+	scan(
+	    scheme: "ABA Music",
+	    device: options[:device],
+	    sdk: "iphonesimulator" + "#{ios_version}",
+	    clean: true,
+	    disable_concurrent_testing: true
+  	)
+end
+
+###############
+# Build lanes #
+###############
+
+desc "Builds the app for the specified iOS version."
+desc "This lane is to make sure that the app builds correctly before running any test, thus catching compilation errors early."
+desc "Usage example: fastlane build_app ios_version:'12.4'"
+lane :compile_app do |options|
+	raise "Missing 'ios_version' parameter. Usage: fastlane build_app ios_version:IOS_VERSION" unless options[:ios_version]
+	ios_version = options[:ios_version]
+	xcbuild(
+		scheme: "ABA Music",
+		sdk: "iphonesimulator" + "#{ios_version}",
+		clean: true
+	)
+end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -58,9 +58,9 @@ end
 
 desc "Builds the app for the specified iOS version."
 desc "This lane is to make sure that the app builds correctly before running any test, thus catching compilation errors early."
-desc "Usage example: fastlane build_app ios_version:'12.4'"
+desc "Usage example: fastlane compile_app ios_version:'12.4'"
 lane :compile_app do |options|
-	raise "Missing 'ios_version' parameter. Usage: fastlane build_app ios_version:IOS_VERSION" unless options[:ios_version]
+	raise "Missing 'ios_version' parameter. Usage: fastlane compile_app ios_version:IOS_VERSION" unless options[:ios_version]
 	ios_version = options[:ios_version]
 	xcbuild(
 		scheme: "ABA Music",

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -29,6 +29,22 @@ fastlane ui_test
 Runs app's UI tests in the specified device.
 
 Usage example: fastlane ui_test device:'iPhone 8' ios_version:'12.4'
+### full_test
+```
+fastlane full_test
+```
+Runs app's full test suite in the specified device.
+
+Usage example: fastlane full_test device:'iPhone 8' ios_version:'12.4'
+### compile_app
+```
+fastlane compile_app
+```
+Builds the app for the specified iOS version.
+
+This lane is to make sure that the app builds correctly and that breaking API changes are detected before deployment.
+
+Usage example: fastlane build_app ios_version:'12.4'
 
 ----
 


### PR DESCRIPTION
We improve the CI setup by adding the following lanes:
* Compile: We make sure the app compiles before trying to run any test. In this way, compilation errors are catched earlier.
* Coverage: We run the complete tests suite to gather code coverage reports once and make reports cleaner.
* Slather: We remove slather execution from individual testing jobs.
* Minor changes on jobs execution conditions.